### PR TITLE
Predictable fixture ordering

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401, E731
+max-line-length = 79
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/derex/openedx/nostatic/restore_dump.py
+++ b/derex/openedx/nostatic/restore_dump.py
@@ -48,7 +48,9 @@ def run_fixtures():
         variant_dir = fixtures_dir / variant
         if not variant_dir.exists():
             continue
-        for file in variant_dir.listdir():
+        # We sort lexicographically by file name
+        # to make predictable ordering possible
+        for file in sorted(variant_dir.listdir()):
             path("/openedx/edx-platform").chdir()
             os.system("./manage.py {} loaddata {}".format(variant, file))
 


### PR DESCRIPTION
The reset_mysql script can load django feaatures too.

It should do this in a predictable order to let users correctly sort their fixtures according to interdependencies.